### PR TITLE
Ensure that overlay lines stay on top of the codex etc.

### DIFF
--- a/PrintUtil/PrintUtil.lua
+++ b/PrintUtil/PrintUtil.lua
@@ -44,7 +44,7 @@ function PrintUtil.createOverlayLine(obstacleName, text, kwargs)
             Name = "BlankObstacle",
             X = x_pos,
             Y = y_pos,
-            Group = "Combat_Menu_Overlay"
+            Group = "Combat_Menu_TraitTray_Overlay"
         })
 
         CreateTextBox(


### PR DESCRIPTION
See SetupMap() in  Scripts/RoomManager.lua for the list of UI element groups.
Combat_Menu_TraitTray_Overlay is the frontmost non-Additive group
(additive groups behave slightly oddly and aren't appropriate for this).